### PR TITLE
WIP: Exclude some invalid links in check-links.yml

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -31,6 +31,12 @@ jobs:
         # 429: Too many requests
         args: >
           --accept 429
+        #  --exclude ".*.md$"
+          --exclude "http://bssa.geoscienceworld.org/"
+          --exclude "https://academic.oup.com/astrogeo"
+          --exclude "https://www.scopus.com/"
+          --exclude "http://geophysics.geoscienceworld.org/"
+          --exclude "http://localhost:1313/"
           --verbose
           "repository/README.md"
           "website/**/*.html"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -31,7 +31,6 @@ jobs:
         # 429: Too many requests
         args: >
           --accept 429
-        #  --exclude ".*.md$"
           --exclude "http://bssa.geoscienceworld.org/"
           --exclude "https://academic.oup.com/astrogeo"
           --exclude "https://www.scopus.com/"


### PR DESCRIPTION
Since there are lots of invalid links that need to be updated or removed, some of us can fix them when we begin to work on those links.

Fixes #34.