### PR TITLE
Update regional earthquake catalogs

### DIFF
--- a/TODO/database.md
+++ b/TODO/database.md
@@ -152,44 +152,8 @@ slug: database
     - [Global heat flow database](https://ihfc-iugg.org/products/global-heat-flow-database)
     - [Global surface heat flow database (version of 2012)](http://www.lithosphere.info/downloads.html)
 
-
-
-
 ---------------------
 ## Earthquake Catalog
-
-### Global Earthquake Catalog
-
-- [IRIS web service](http://service.iris.edu/fdsnws/event/1)
-- [ISC Bulletin](http://www.isc.ac.uk/iscbulletin/search/catalogue) | [ISC web service](http://www.isc.ac.uk/fdsnws/event/1)
-- [ISC-EHB Bulletin](http://www.isc.ac.uk/isc-ehb)
-- [ISC-GEM Catalogue](http://www.isc.ac.uk/iscgem): ISC-GEM Global Instrumental Earthquake Catalogue (1904-2015) | [Introduction](https://storage.globalquakemodel.org/what/seismic-hazard/instrumental-catalogue)
-- [USGS Preliminary Determination of Epicenters (PDE)](https://earthquake.usgs.gov/data/pde.php) | [Chinese introduction](https://blog.seisman.info/global-earthquake-catalog-pde)
-- [USGS ANSS Comprehensive Earthquake Catalog (ComCat)](https://earthquake.usgs.gov/data/comcat) | [USGS web service](https://earthquake.usgs.gov/fdsnws/event/1) | [ComCat Wrapper Libraries](https://www.usgs.gov/software/comcat-wrapper-libraries)
-    - [Historic ANSS Composite Catalog](https://ncedc.org/anss/catalog-search.html)
-- [EMSC catalog](https://www.emsc-csem.org/Earthquake/?filter=yes)
-- [Global Earthquake History](https://emidius.eu/GEH): [Introduction](https://storage.globalquakemodel.org/what/seismic-hazard/historical-catalogue)
-
-
-
-### Regional Earthquake Catalog
-
-- [中国台网正式地震目录](http://data.earthquake.cn/datashare/report.shtml?PAGEID=earthquake_zhengshi)：统一的中国地震台网地震目录
-- [中国历史地震目录](http://data.earthquake.cn/data/data/history_query.jsp)
-- [中国台网统一地震目录](http://data.earthquake.cn/data/datashare_tyml_query.jsp): 无法打开
-- [Euro-Med Bulletin](https://www.emsc-csem.org/Bulletin)
-- [Dissemination of long-term seismological data](https://www.emidius.eu)
-    - [European Archive of Historical EArthquake Data (AHEAD)](https://www.emidius.eu/AHEAD)
-    - [Share European Earthquake Catalogue (SHEEC)](https://www.emidius.eu/SHEEC)
-- [SCSN Catalog](http://service.scedc.caltech.edu/eq-catalogs/date_mag_loc.php) | [SCEDC web service](http://service.scedc.caltech.edu/fdsnws/event/1)
-- [NCSN Catalog](https://ncedc.org/ncedc/catalog-search.html) | [NCEDC web service](http://service.ncedc.org/fdsnws/event/1)
-- [Egill Hauksson's relocated catalog from SCSN](https://service.scedc.caltech.edu/ftp/catalogs/hauksson/Socal_DD/)
-- [Canada National Earthquake DataBase](http://www.earthquakescanada.nrcan.gc.ca/stndon/NEDB-BNDS/index-en.php)
-- JMA catalog | [Chinese note](https://blog.seisman.info/trash/jma-unified-hypocenter-catalog)
-    - [JMA Unified Hypocenter Catalog](https://hinetwww11.bosai.go.jp/auth/JMA/jmalist.php): Hinet provides event waveform data, arrivel time data and focal mechanism based on the catalog.
-    - [The Seismological Bulletin of Japan](http://www.data.jma.go.jp/svd/eqev/data/bulletin/hypo_e.html): Final version of JMA Unified Hypocenter Catalog
-- [Australia Earthquakes](https://earthquakes.ga.gov.au)
-
 
 ### Focal Mechanism Catalog
 

--- a/content/database.md
+++ b/content/database.md
@@ -12,7 +12,8 @@ toc: true
   [FDSN Event Web Service](http://www.isc.ac.uk/fdsnws/event/1/)
 - [ISC-EHB Bulletin](http://www.isc.ac.uk/isc-ehb/) |
   [Catalog Search](http://www.isc.ac.uk/isc-ehb/search/)
-- [ISC-GEM Earthquake Catalog](http://www.isc.ac.uk/iscgem/)
+- [ISC-GEM Earthquake Catalog](http://www.isc.ac.uk/iscgem/) |
+  [Brief Introduction](https://storage.globalquakemodel.org/what/seismic-hazard/instrumental-catalogue)
 - [中国台网正式地震目录](https://data.earthquake.cn/datashare/report.shtml?PAGEID=earthquake_zhengshi)
 - [European-Mediterranean Seismological Centre Earthquake Catalog](https://www.emsc-csem.org/Earthquake/?filter=yes)
 - [USGS ANSS Comprehensive Earthquake Catalog](https://earthquake.usgs.gov/data/comcat/) | 

--- a/content/database.md
+++ b/content/database.md
@@ -12,23 +12,36 @@ toc: true
 - [ISC-EHB Bulletin](http://www.isc.ac.uk/isc-ehb/) |
   [Searching ISC-EHB Bulletin](http://www.isc.ac.uk/isc-ehb/search/)
 - [ISC-GEM Earthquake Catalog](http://www.isc.ac.uk/iscgem/)
-- [Global Historical Earthquake Archive (1000-1903)](https://emidius.eu/GEH/)
+- [中国台网正式地震目录](https://data.earthquake.cn/datashare/report.shtml?PAGEID=earthquake_zhengshi)
 - [EMSC Earthquake Catalog](https://www.emsc-csem.org/Earthquake/?filter=yes)
 - [USGS ANSS Comprehensive Earthquake Catalog](https://earthquake.usgs.gov/data/comcat/) | 
-  [Search Earthquake Catalog](http://earthquake.usgs.gov/earthquakes/search/) |
+  [Catalog Search](http://earthquake.usgs.gov/earthquakes/search/) |
   [FDSN Event Web Service](http://earthquake.usgs.gov/fdsnws/event/1/)
 - [USGS PDE](https://earthquake.usgs.gov/data/comcat/catalog/us/)
-- [中国台网正式地震目录](https://data.earthquake.cn/datashare/report.shtml?PAGEID=earthquake_zhengshi)
+- [Global Historical Earthquake Archive (1000-1903)](https://emidius.eu/GEH/)
 
 ### Regional Earthquake Catalog
 
-- [Catalog of Historical Earthquakes in China](http://data.earthquake.cn/data/data/history_query.jsp): From B.C. 1831 to A.D. 1969
-- [Northern California Earthquake Catalog](http://www.ncedc.org/ncedc/catalog-search.html)
-- [Southern California Earthquake Catalog](http://service.scedc.caltech.edu/eq-catalogs/date_mag_loc.php)
-- [JMA Unified Hypocenter Catalog](http://www.data.jma.go.jp/svd/eqev/data/bulletin/hypo_e.html)
-- [JMA Preliminary Unified Hypocenter Catalog](https://hinetwww11.bosai.go.jp/auth/JMA/jmalist.php)
-- [Australian Catalog](http://www.ga.gov.au/earthquakes/searchQuake.do)
-- [Canada Catalog](http://www.earthquakescanada.nrcan.gc.ca/stndon/NEDB-BNDS/bull-en.php)
+- [中国历史地震目录](https://data.earthquake.cn/datashare/report.shtml?PAGEID=earthquake_lsdz):
+  公元前 1831 年至公元 1969 年间发生在中国的破坏性地震（M>=4.0）
+- [Japan Meteorological Agency (JMA) Unified Hypocenter Catalog](http://www.data.jma.go.jp/svd/eqev/data/bulletin/hypo_e.html)
+- [JMA Unified Hypocenter Catalog (Preliminary)](https://hinetwww11.bosai.go.jp/auth/JMA/jmalist.php):
+  The hypocenters are preliminary results and JMA may revise them.
+- [Canada Catalog](http://www.earthquakescanada.nrcan.gc.ca/stndon/NEDB-BNDS/bull-en.php) |
+  [Catalog Search](https://www.earthquakescanada.nrcan.gc.ca/stndon/NEDB-BNDS/bulletin-en.php)
+- [Northern California Earthquake Catalog](http://www.ncedc.org/ncedc/catalog-search.html) |
+  [FDSN Event Web Service](http://service.ncedc.org/fdsnws/event/1/)
+- [Southern California Earthquake Catalogs](https://scedc.caltech.edu/eq-catalogs/) |
+  [Catalog Search](https://service.scedc.caltech.edu/eq-catalogs/date_mag_loc.php) |
+  [FDSN Event Web Service](https://service.scedc.caltech.edu/fdsnws/event/1/)
+- [Southern California refined earthquake focal mechanism catalog](https://scedc.caltech.edu/data/alt-2011-yang-hauksson-shearer.html)
+- [European-Mediterranean Catalog](https://www.emsc-csem.org/Bulletin/) |
+  [Catalog Search](https://www.emsc-csem.org/Bulletin/search.php?filter=yes)
+- [European Archive of Historical Earthquake Data](https://www.emidius.eu/AHEAD/)
+- [SHARE European Earthquake Catalog](https://www.emidius.eu/SHEEC/) |
+  [1000-1899](https://www.emidius.eu/SHEEC/sheec_1000_1899.html) |
+  [1900-2006](https://www.gfz-potsdam.de/en/section/seismic-hazard-and-risk-dynamics/data-products-services/sheec-earthquake-catalogue/)
+- [Australian Catalog](https://earthquakes.ga.gov.au/)
 
 ## Focal Mechanism Catalog
 

--- a/content/database.md
+++ b/content/database.md
@@ -18,7 +18,8 @@ toc: true
 - [European-Mediterranean Seismological Centre Earthquake Catalog](https://www.emsc-csem.org/Earthquake/?filter=yes)
 - [USGS ANSS Comprehensive Earthquake Catalog](https://earthquake.usgs.gov/data/comcat/) | 
   [Catalog Search](http://earthquake.usgs.gov/earthquakes/search/) |
-  [FDSN Event Web Service](http://earthquake.usgs.gov/fdsnws/event/1/)
+  [FDSN Event Web Service](http://earthquake.usgs.gov/fdsnws/event/1/) |
+  [Wrapper Libraries](https://www.usgs.gov/software/comcat-wrapper-libraries)
 - [USGS PDE](https://earthquake.usgs.gov/data/comcat/catalog/us/)
 - [Global Historical Earthquake Archive (1000-1903)](https://emidius.eu/GEH/) |
   [Brief Introduction](https://storage.globalquakemodel.org/what/seismic-hazard/historical-catalogue)

--- a/content/database.md
+++ b/content/database.md
@@ -13,7 +13,7 @@ toc: true
   [Catalog Search](http://www.isc.ac.uk/isc-ehb/search/)
 - [ISC-GEM Earthquake Catalog](http://www.isc.ac.uk/iscgem/)
 - [中国台网正式地震目录](https://data.earthquake.cn/datashare/report.shtml?PAGEID=earthquake_zhengshi)
-- [EMSC Earthquake Catalog](https://www.emsc-csem.org/Earthquake/?filter=yes)
+- [European-Mediterranean Seismological Centre Earthquake Catalog](https://www.emsc-csem.org/Earthquake/?filter=yes)
 - [USGS ANSS Comprehensive Earthquake Catalog](https://earthquake.usgs.gov/data/comcat/) | 
   [Catalog Search](http://earthquake.usgs.gov/earthquakes/search/) |
   [FDSN Event Web Service](http://earthquake.usgs.gov/fdsnws/event/1/)

--- a/content/database.md
+++ b/content/database.md
@@ -8,7 +8,8 @@ toc: true
 ### Global Earthquake Catalog
 
 - [ISC Bulletin](http://www.isc.ac.uk/iscbulletin) |
-  [Catalog Search](http://www.isc.ac.uk/iscbulletin/search/)
+  [Catalog Search](http://www.isc.ac.uk/iscbulletin/search/) |
+  [FDSN Event Web Service](http://www.isc.ac.uk/fdsnws/event/1/)
 - [ISC-EHB Bulletin](http://www.isc.ac.uk/isc-ehb/) |
   [Catalog Search](http://www.isc.ac.uk/isc-ehb/search/)
 - [ISC-GEM Earthquake Catalog](http://www.isc.ac.uk/iscgem/)

--- a/content/database.md
+++ b/content/database.md
@@ -20,7 +20,8 @@ toc: true
   [Catalog Search](http://earthquake.usgs.gov/earthquakes/search/) |
   [FDSN Event Web Service](http://earthquake.usgs.gov/fdsnws/event/1/)
 - [USGS PDE](https://earthquake.usgs.gov/data/comcat/catalog/us/)
-- [Global Historical Earthquake Archive (1000-1903)](https://emidius.eu/GEH/)
+- [Global Historical Earthquake Archive (1000-1903)](https://emidius.eu/GEH/) |
+  [Brief Introduction](https://storage.globalquakemodel.org/what/seismic-hazard/historical-catalogue)
 
 ### Regional Earthquake Catalog
 

--- a/content/database.md
+++ b/content/database.md
@@ -32,7 +32,7 @@ toc: true
 - [Japan Meteorological Agency (JMA) Unified Hypocenter Catalog](http://www.data.jma.go.jp/svd/eqev/data/bulletin/hypo_e.html)
 - [JMA Unified Hypocenter Catalog (Preliminary)](https://hinetwww11.bosai.go.jp/auth/JMA/jmalist.php):
   The hypocenters are preliminary results and JMA may revise them.
-- [Canada Catalog](http://www.earthquakescanada.nrcan.gc.ca/stndon/NEDB-BNDS/bull-en.php) |
+- [Canada Catalog](https://www.earthquakescanada.nrcan.gc.ca/stndon/NEDB-BNDS/index-en.php) |
   [Catalog Search](https://www.earthquakescanada.nrcan.gc.ca/stndon/NEDB-BNDS/bulletin-en.php)
 - [Northern California Earthquake Catalog](http://www.ncedc.org/ncedc/catalog-search.html) |
   [FDSN Event Web Service](http://service.ncedc.org/fdsnws/event/1/)

--- a/content/database.md
+++ b/content/database.md
@@ -8,9 +8,9 @@ toc: true
 ### Global Earthquake Catalog
 
 - [ISC Bulletin](http://www.isc.ac.uk/iscbulletin) |
-  [Searching ISC Bulletin](http://www.isc.ac.uk/iscbulletin/search/)
+  [Catalog Search](http://www.isc.ac.uk/iscbulletin/search/)
 - [ISC-EHB Bulletin](http://www.isc.ac.uk/isc-ehb/) |
-  [Searching ISC-EHB Bulletin](http://www.isc.ac.uk/isc-ehb/search/)
+  [Catalog Search](http://www.isc.ac.uk/isc-ehb/search/)
 - [ISC-GEM Earthquake Catalog](http://www.isc.ac.uk/iscgem/)
 - [中国台网正式地震目录](https://data.earthquake.cn/datashare/report.shtml?PAGEID=earthquake_zhengshi)
 - [EMSC Earthquake Catalog](https://www.emsc-csem.org/Earthquake/?filter=yes)

--- a/content/database.md
+++ b/content/database.md
@@ -34,7 +34,7 @@ toc: true
 - [Southern California Earthquake Catalogs](https://scedc.caltech.edu/eq-catalogs/) |
   [Catalog Search](https://service.scedc.caltech.edu/eq-catalogs/date_mag_loc.php) |
   [FDSN Event Web Service](https://service.scedc.caltech.edu/fdsnws/event/1/)
-- [Southern California refined earthquake focal mechanism catalog](https://scedc.caltech.edu/data/alt-2011-yang-hauksson-shearer.html)
+- [Southern California Refined Earthquake Catalog](https://scedc.caltech.edu/data/alt-2011-yang-hauksson-shearer.html)
 - [European-Mediterranean Catalog](https://www.emsc-csem.org/Bulletin/) |
   [Catalog Search](https://www.emsc-csem.org/Bulletin/search.php?filter=yes)
 - [European Archive of Historical Earthquake Data](https://www.emidius.eu/AHEAD/)

--- a/content/database.md
+++ b/content/database.md
@@ -19,7 +19,8 @@ toc: true
 - [USGS ANSS Comprehensive Earthquake Catalog](https://earthquake.usgs.gov/data/comcat/) | 
   [Catalog Search](http://earthquake.usgs.gov/earthquakes/search/) |
   [FDSN Event Web Service](http://earthquake.usgs.gov/fdsnws/event/1/) |
-  [Wrapper Libraries](https://www.usgs.gov/software/comcat-wrapper-libraries)
+  [Wrapper Libraries](https://www.usgs.gov/software/comcat-wrapper-libraries) |
+  [Historic ANSS Composite Catalog](https://ncedc.org/anss/catalog-search.html)
 - [USGS PDE](https://earthquake.usgs.gov/data/comcat/catalog/us/)
 - [Global Historical Earthquake Archive (1000-1903)](https://emidius.eu/GEH/) |
   [Brief Introduction](https://storage.globalquakemodel.org/what/seismic-hazard/historical-catalogue)


### PR DESCRIPTION
Although we may want to sort the catalogs alphabetically for global earthquake catalogs, I think we may put the most important ones at the first and something non-important at the end.
- Move **中国台网正式地震目录** just after ISC since we may want to focus on Chinese seismological studies
- Put **Global Historical Earthquake Archive (1000-1903)** at the end since it is not commonly used
- Some tiny fixes

For the regional catalogs, I collect catalogs at the same continent together and sort them alphabetically.
- Asia
- North America
- Europe
- Australia

Address #51.

