### PR TITLE
Remove one link from learning

### DIFF
--- a/content/learning.md
+++ b/content/learning.md
@@ -18,7 +18,3 @@ title: Learning Resources
 ### NumPy
 
 - [A Visual Intro to NumPy and Data Representation](http://jalammar.github.io/visual-numpy/)
-
-## Miscellaneous
-
-- [Essential Image Optimization](https://images.guide/)


### PR DESCRIPTION
The site is redirected to a new site. The new site contains too much information.
