### PR TITLE
Update link order on the landing page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -7,12 +7,12 @@ cards:
   - name: Codes
     link: codes
     icon: fa-code
-  - name: Learning
-    link: learning
-    icon: fa-graduation-cap
   - name: Database
     link: database
     icon: fa-database
+  - name: Learning
+    link: learning
+    icon: fa-graduation-cap
   - name: Jobs
     link: jobs
     icon: fa-ad


### PR DESCRIPTION
I'd like to put `database` ahead of `learning`.