### PR TITLE
Remove IASPEI phase names

### DIFF
--- a/content/learning.md
+++ b/content/learning.md
@@ -6,9 +6,8 @@ title: Learning Resources
 
 ### Short Videos & Posts
 
-- [Focal Mechanisms Explained: What are those “beach balls”?](https://www.youtube.com/watch?v=MomVOkyDdLo): A 6-minute video explaining beachballs for non-seismologists and beginners.
-- [IASPEI standard phase list](http://www.isc.ac.uk/standards/phases/)
-- [SEED Channel Naming](https://ds.iris.edu/ds/nodes/dmc/data/formats/seed-channel-naming/): Explain channel code for seismic waveform data.
+- [Focal Mechanisms Explained: What are those “beach balls”?](https://www.youtube.com/watch?v=MomVOkyDdLo): A 6-minute video explaining beachballs for non-seismologists and beginners
+- [SEED Channel Naming](https://ds.iris.edu/ds/nodes/dmc/data/formats/seed-channel-naming/): Explain channel code for seismic waveform data
 
 ### Workshops & Courses
 


### PR DESCRIPTION
We have it on https://seismo-learn.org/seismology/ray-theory-travel-times/ray-nomenclature/. I think users may remember to find it on that page.