### PR TITLE
Bump hugo version to 0.86.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2.5.0
         with:
-          hugo-version: 0.86.0
+          hugo-version: 0.86.1
           extended: true
 
       - name: Build the website

--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2.5.0
         with:
-          hugo-version: 0.86.0
+          hugo-version: 0.86.1
           extended: true
 
       - name: Change Hugo baseurl so that PR preview works


### PR DESCRIPTION
I made a tiny update for sci-hub in https://github.com/seismo-learn/links/commit/b46eb63fb2adb3971520389460be1beded35e34b, but I made a mistake to click to commit to the main branch.