### PR TITLE
Fully customize the build process of the ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,5 +14,4 @@ build:
     # https://docs.readthedocs.io/en/stable/build-customization.html#override-the-build-process
     - curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.111.3/hugo_extended_0.111.3_Linux-64bit.tar.gz | tar zxvf - hugo
     - sed -i "s#https://seismo-learn.org/links/#${READTHEDOCS_CANONICAL_URL}#" config.toml
-    - ./hugo
-    - mv public $READTHEDOCS_OUTPUT/html/
+    - ./hugo -d $READTHEDOCS_OUTPUT/html/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,6 @@ build:
   commands:
     # Full cusotmized build process
     # https://docs.readthedocs.io/en/stable/build-customization.html#override-the-build-process
-    - curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.111.3/hugo_extended_0.111.3_Linux-64bit.tar.gz | tar zxvf - hugo
+    - curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.117.0/hugo_extended_0.117.0_Linux-64bit.tar.gz | tar zxvf - hugo
     - sed -i "s#https://seismo-learn.org/links/#${READTHEDOCS_CANONICAL_URL}#" config.toml
     - ./hugo -d $READTHEDOCS_OUTPUT/html/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,15 +8,11 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
     golang: "1.19"  # needed by hugo
-  jobs:
-    post_build:
-      # remove the HTML built by Sphinx
-      - rm -rvf _readthedocs/html
-      # Install hugo and build the website
-      - wget https://github.com/gohugoio/hugo/releases/download/v0.111.3/hugo_extended_0.111.3_Linux-64bit.tar.gz
-      - tar -xvf hugo_extended_0.111.3_Linux-64bit.tar.gz
-      - sed -i "s#https://seismo-learn.org/links/#${READTHEDOCS_CANONICAL_URL}#" config.toml
-      - ./hugo
-      - mv public _readthedocs/html
+  commands:
+    # Full cusotmized build process
+    # https://docs.readthedocs.io/en/stable/build-customization.html#override-the-build-process
+    - curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.111.3/hugo_extended_0.111.3_Linux-64bit.tar.gz | tar zxvf - hugo
+    - sed -i "s#https://seismo-learn.org/links/#${READTHEDOCS_CANONICAL_URL}#" config.toml
+    - ./hugo
+    - mv public $READTHEDOCS_OUTPUT/html/


### PR DESCRIPTION
ReadTheDocs only support Sphinx officially, but it's possible to fully customize the build process so that we can use tools other than Sphinx (e.g., hugo for this site) to build the site.

Reference: https://docs.readthedocs.io/en/stable/build-customization.html#override-the-build-process